### PR TITLE
Implement document upload endpoint

### DIFF
--- a/rest.http
+++ b/rest.http
@@ -80,6 +80,21 @@ Content-Type: application/json
   "stream": false
 }
 
+### Upload Document to Active Project (PDF example)
+POST http://localhost:8000/v1/documents/upload
+Content-Type: multipart/form-data
+
+--boundary
+Content-Disposition: form-data; name="file"; filename="sample.pdf"
+Content-Type: application/pdf
+
+(binary content would go here)
+--boundary
+Content-Disposition: form-data; name="user"
+
+guest_user
+--boundary--
+
 
 
 # Goal: Allow users to upload documents via OpenWebUI, which are then processed and added to the RAG knowledge base of their currently active project.

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,6 +6,10 @@ httpx
 sqlalchemy
 chromadb                # Vector store
 sentence-transformers   # For generating text embeddings
+# Libraries for document parsing
+python-docx
+PyPDF2
+openpyxl
 # tiktoken              # Optional, but often useful with sentence-transformers or for token counting
 
 


### PR DESCRIPTION
## Summary
- support uploading a document via `/v1/documents/upload`
- add document parsing for txt, md, docx, pdf and excel
- extend seeding function to use new parser
- update example request in `rest.http`
- add parsing dependencies to requirements

## Testing
- `python -m py_compile server/app/main.py server/app/services/rag_service.py server/app/services/chat_service.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840ac568950832c8a0638bcddb5e7fc